### PR TITLE
Update to Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevy_vox_mesh"
 description = "A bevy engine plugin for loading magica voxel files directly in bevy as usable meshes."
 license = "MIT"
-version = "0.7.1"
+version = "0.8.0"
 repository = "https://github.com/Game4all/bevy_vox_mesh"
 authors = ["Lucas A. <game4allyt@gmail.com>"]
 edition = "2021"
@@ -11,7 +11,7 @@ exclude = ["assets/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.11.0", default-features = false, features = [
+bevy = { version = "0.12.0", default-features = false, features = [
   "bevy_render",
   "bevy_asset",
 ] }
@@ -20,9 +20,10 @@ ndshape = "0.3.0"
 block-mesh = "0.2.0"
 ndcopy = "0.3.0"
 anyhow = "1.0.38"
+thiserror = "1.0.50"
 
 [dev-dependencies]
-bevy = { version = "0.11.0" }
+bevy = { version = "0.12.0" }
 
 [[example]]
 name = "basic"

--- a/README.md
+++ b/README.md
@@ -66,3 +66,5 @@ Take a look in the `examples/` directory for a complete working example.
 ## Acknowledgements
 
 This asset loader is powered by the awesome [`block-mesh-rs`](https://github.com/bonsairobo/block-mesh-rs) crate.
+
+Ported to bevy 0.12.0 thanks to @baranyildirim.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A plugin for the bevy engine which allows loading magica voxel `.vox` files dire
 | 0.9          | 0.5            |
 | 0.10         | 0.6            |
 | 0.11         | 0.7, 0.7.1     |
+| 0.12         | 0.8            |
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 
 use bevy::{
     app::{App, Plugin},
-    prelude::AddAsset,
+    asset::AssetApp,
 };
 use block_mesh::{QuadCoordinateConfig, RIGHT_HANDED_Y_UP_CONFIG};
 
@@ -61,7 +61,7 @@ impl Default for VoxMeshPlugin {
 
 impl Plugin for VoxMeshPlugin {
     fn build(&self, app: &mut App) {
-        app.add_asset_loader(VoxLoader {
+        app.register_asset_loader(VoxLoader {
             config: self.config.clone(),
             v_flip_face: self.v_flip_faces,
         });

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,6 +1,11 @@
-use anyhow::{anyhow, Error};
-use bevy::asset::{AssetLoader, LoadContext, LoadedAsset};
+use anyhow::{anyhow, Context};
+use bevy::{
+    asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext, LoadedAsset},
+    render::mesh::Mesh,
+    utils::BoxedFuture,
+};
 use block_mesh::QuadCoordinateConfig;
+use thiserror::Error;
 
 /// An asset loader capable of loading models in `.vox` files as usable [`bevy::render::mesh::Mesh`]es.
 ///
@@ -13,15 +18,30 @@ pub struct VoxLoader {
     pub(crate) v_flip_face: bool,
 }
 
+#[derive(Error, Debug)]
+pub enum VoxLoaderError {
+    #[error(transparent)]
+    InvalidAsset(#[from] anyhow::Error),
+}
+
 impl AssetLoader for VoxLoader {
+    type Asset = Mesh;
+    type Settings = ();
+    type Error = VoxLoaderError;
+
     fn load<'a>(
         &'a self,
-        bytes: &'a [u8],
+        reader: &'a mut Reader,
+        _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext,
-    ) -> bevy::utils::BoxedFuture<'a, Result<(), Error>> {
+    ) -> BoxedFuture<'a, Result<Self::Asset, VoxLoaderError>> {
         Box::pin(async move {
-            self.process_vox_file(bytes, load_context)?;
-            Ok(())
+            let mut bytes = Vec::new();
+            reader
+                .read_to_end(&mut bytes)
+                .await
+                .map_err(|e| VoxLoaderError::InvalidAsset(anyhow!(e)))?;
+            Ok(self.process_vox_file(&bytes, load_context)?)
         })
     }
 
@@ -35,10 +55,10 @@ impl VoxLoader {
         &self,
         bytes: &'a [u8],
         load_context: &'a mut LoadContext,
-    ) -> Result<(), Error> {
+    ) -> Result<Mesh, VoxLoaderError> {
         let file = match dot_vox::load_bytes(bytes) {
             Ok(data) => data,
-            Err(error) => return Err(anyhow!(error)),
+            Err(error) => return Err(VoxLoaderError::InvalidAsset(anyhow!(error))),
         };
 
         let palette: Vec<[f32; 4]> = file
@@ -47,6 +67,7 @@ impl VoxLoader {
             .map(|color| color.to_le_bytes().map(|byte| byte as f32 / u8::MAX as f32))
             .collect();
 
+        let mut default_mesh: Option<Mesh> = None;
         for (index, model) in file.models.iter().enumerate() {
             let (shape, buffer) = crate::voxel::load_from_model(model);
             let mesh =
@@ -54,17 +75,14 @@ impl VoxLoader {
 
             match index {
                 0 => {
-                    load_context.set_default_asset(LoadedAsset::new(mesh.clone()));
+                    default_mesh = Some(mesh);
                 }
                 _ => {
-                    load_context.set_labeled_asset(
-                        &format!("model{}", index),
-                        LoadedAsset::new(mesh.clone()),
-                    );
+                    load_context.add_labeled_asset(format!("model{}", index), mesh);
                 }
             }
         }
 
-        Ok(())
+        Ok(default_mesh.context("No models found in vox file")?)
     }
 }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context};
 use bevy::{
-    asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext, LoadedAsset},
+    asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
     render::mesh::Mesh,
     utils::BoxedFuture,
 };


### PR DESCRIPTION
Changed AssetLoader impl to be compatible with Bevy 0.12.0
Introduced VoxLoaderError to satisfy type Error requirement
Bumped version to 0.8